### PR TITLE
replace uint64_t with uint64 to fix build

### DIFF
--- a/SteamworksPy.cpp
+++ b/SteamworksPy.cpp
@@ -248,7 +248,7 @@ SW_PY int GetFriendCount(int flag){
 	}
 	return SteamFriends()->GetFriendCount(flag);
 }
-SW_PY uint64_t GetFriendByIndex(int thisFriend){
+SW_PY uint64 GetFriendByIndex(int thisFriend){
 	CSteamID friendID = SteamFriends()->GetFriendByIndex(thisFriend, 0xFFFF);
 	return friendID.ConvertToUint64();
 }
@@ -444,7 +444,7 @@ SW_PY void TriggerScreenshot(){
 //-----------------------------------------------
 // Steam User
 //-----------------------------------------------
-SW_PY uint64_t GetSteamID(){
+SW_PY uint64 GetSteamID(){
 	if(SteamUser() == NULL){
 		return 0;
 	}


### PR DESCRIPTION
build fails for me:
```
g++ -std=c++11 -o SteamworksPy.so -shared -fPIC SteamworksPy.cpp -l steam_api -L.
SteamworksPy.cpp:251:7: error: ‘uint64_t’ does not name a type; did you mean ‘__uint64_t’?
 SW_PY uint64_t GetFriendByIndex(int thisFriend){
       ^~~~~~~~
       __uint64_t
SteamworksPy.cpp:447:7: error: ‘uint64_t’ does not name a type; did you mean ‘__uint64_t’?
 SW_PY uint64_t GetSteamID(){
       ^~~~~~~~
       __uint64_t
make: *** [Makefile:2: makeall] Error 1
```

tested with 
gcc version 8.2.0 (Gentoo 8.2.0-r6 p1.7)
gcc version 7.3.0 (Gentoo 7.3.0-r3 p1.4)