### PR TITLE
Fix argtypes in Workshop_SuspendDownloads 

### DIFF
--- a/steamworks/methods.py
+++ b/steamworks/methods.py
@@ -370,7 +370,7 @@ STEAMWORKS_METHODS = {
     },
     'Workshop_SuspendDownloads': {
         'restype': None,
-        'argtypes': [bool]
+        'argtypes': [c_bool]
     },
     'Workshop_SubscribeItem': {
         'restype': None,


### PR DESCRIPTION
bool -> c_bool
It causes 'TypeError: item 1 in _argtypes_ has no from_param method'