### PR TITLE
Fix indention and enums

### DIFF
--- a/steamworks/interfaces/friends.py
+++ b/steamworks/interfaces/friends.py
@@ -20,7 +20,7 @@ class SteamFriends(object):
         :param flag: FriendFlags
         :return: int
         """
-        return self.steam.GetFriendCount(flag)
+        return self.steam.GetFriendCount(flag.value)
 
     #
     def GetFriendByIndex(self, friend_index: int, flag: bytes = FriendFlags.ALL) -> int:
@@ -30,7 +30,7 @@ class SteamFriends(object):
         :param flag: FriendFlags
         :return: int steam64
         """
-        return self.steam.GetFriendByIndex(friend_index, flag)
+        return self.steam.GetFriendByIndex(friend_index, flag.value)
 
 
     def GetPlayerName(self) -> str:

--- a/steamworks/interfaces/users.py
+++ b/steamworks/interfaces/users.py
@@ -49,7 +49,7 @@ class SteamUsers(object):
         return self.steam.GetGameBadgeLevel(series, foil)
 		
     def GetAuthSessionTicket(self) -> str:
-		"""Retrieves an authentication ticket. Immediately usable in AuthenticateUserTicket.
+        """Retrieves an authentication ticket. Immediately usable in AuthenticateUserTicket.
 		
 		:return: str
 		"""


### PR DESCRIPTION
The docstring on the GetAuthSessionTicket created an error in VSCode.

The enums accessed by 2 friend function didnt accessed the value but instea the Name: Value