### PR TITLE
ItemSubscribed/ItemUnsubscribed callbacks cross-platform compatibility

### DIFF
--- a/library/SteamworksPy.cpp
+++ b/library/SteamworksPy.cpp
@@ -84,8 +84,14 @@
 typedef void(*CreateItemResultCallback_t)(CreateItemResult_t);
 typedef void(*SubmitItemUpdateResultCallback_t)(SubmitItemUpdateResult_t);
 typedef void(*ItemInstalledCallback_t)(ItemInstalled_t);
-typedef void(*RemoteStorageSubscribeFileResultCallback_t)(RemoteStorageSubscribePublishedFileResult_t);
-typedef void(*RemoteStorageUnsubscribeFileResultCallback_t)(RemoteStorageUnsubscribePublishedFileResult_t);
+
+struct SubscriptionResult {
+	std::int32_t result;
+	std::uint64_t publishedFileId;
+};
+
+typedef void(*RemoteStorageSubscribeFileResultCallback_t)(SubscriptionResult);
+typedef void(*RemoteStorageUnsubscribeFileResultCallback_t)(SubscriptionResult);
 typedef void(*LeaderboardFindResultCallback_t)(LeaderboardFindResult_t);
 typedef void(*MicroTxnAuthorizationResponseCallback_t)(MicroTxnAuthorizationResponse_t);
 
@@ -175,13 +181,15 @@ private:
 
     void OnItemSubscribed(RemoteStorageSubscribePublishedFileResult_t *itemSubscribedResult, bool bIOFailure) {
         if (_pyItemSubscribedCallback != nullptr) {
-            _pyItemSubscribedCallback(*itemSubscribedResult);
+            SubscriptionResult result{itemSubscribedResult->m_eResult, itemSubscribedResult->m_nPublishedFileId};
+            _pyItemSubscribedCallback(result);
         }
     }
 
     void OnItemUnsubscribed(RemoteStorageUnsubscribePublishedFileResult_t *itemUnsubscribedResult, bool bIOFailure) {
         if (_pyItemUnsubscribedCallback != nullptr) {
-            _pyItemUnsubscribedCallback(*itemUnsubscribedResult);
+            SubscriptionResult result{itemUnsubscribedResult->m_eResult, itemUnsubscribedResult->m_nPublishedFileId};
+            _pyItemUnsubscribedCallback(result);
         }
     }
 };

--- a/steamworks/interfaces/workshop.py
+++ b/steamworks/interfaces/workshop.py
@@ -11,8 +11,8 @@ class SteamWorkshop(object):
     _CreateItemResult_t 		= CFUNCTYPE(None, CreateItemResult_t)
     _SubmitItemUpdateResult_t 	= CFUNCTYPE(None, SubmitItemUpdateResult_t)
     _ItemInstalled_t 			= CFUNCTYPE(None, ItemInstalled_t)
-    _RemoteStorageSubscribePublishedFileResult_t 	= CFUNCTYPE(None, RemoteStorageSubscribePublishedFileResult_t)
-    _RemoteStorageUnsubscribePublishedFileResult_t 	= CFUNCTYPE(None, RemoteStorageUnsubscribePublishedFileResult_t)
+    _RemoteStorageSubscribePublishedFileResult_t 	= CFUNCTYPE(None, SubscriptionResult)
+    _RemoteStorageUnsubscribePublishedFileResult_t 	= CFUNCTYPE(None, SubscriptionResult)
 
     _CreateItemResult			= None
     _SubmitItemUpdateResult 	= None

--- a/steamworks/methods.py
+++ b/steamworks/methods.py
@@ -417,11 +417,11 @@ STEAMWORKS_METHODS = {
     },
     'Workshop_SetItemSubscribedCallback': {
         'restype': None,
-        'argtypes': [MAKE_CALLBACK(None, structs.RemoteStorageSubscribePublishedFileResult_t)]
+        'argtypes': [MAKE_CALLBACK(None, structs.SubscriptionResult)]
     },
     'Workshop_SetItemUnsubscribedCallback': {
         'restype': None,
-        'argtypes': [MAKE_CALLBACK(None, structs.RemoteStorageUnsubscribePublishedFileResult_t)]
+        'argtypes': [MAKE_CALLBACK(None, structs.SubscriptionResult)]
     },
     'Workshop_SuspendDownloads': {
         'restype': None,

--- a/steamworks/structs.py
+++ b/steamworks/structs.py
@@ -31,19 +31,11 @@ class ItemInstalled_t(Structure):
     ]
 
 
-class RemoteStorageSubscribePublishedFileResult_t(Structure):
+class SubscriptionResult(Structure):
     _fields_ = [
-        ("result", c_int),
+        ("result", c_int32),
         ("publishedFileId", c_uint64)
     ]
-
-
-class RemoteStorageUnsubscribePublishedFileResult_t(Structure):
-    _fields_ = [
-        ("result", c_int),
-        ("publishedFileId", c_uint64)
-    ]
-
 
 class MicroTxnAuthorizationResponse_t(Structure):
     _fields_ = [


### PR DESCRIPTION
The enums used by RemoteStorageSubscribePublishedFileResult_t and RemoteStorageEnumerateUserSubscribedFilesResult_t do not have a fixed underlying type. 

According to the C++ standard, any integral type that can represent all of the values of the enumeration could be a valid choice to store these enums in memory. In Windows the chosen type happens to be an int, but this can be different when using other compilers or platforms.

To prevent these cross-platform issues from affecting the results, the data is now copied into types which must have the same size on all platforms, and that data is then sent to Python.

The changes of this PR have been tested on both Windows and Linux, using the script provided in issue #75.

Fixes #75
