### PR TITLE
Replace SteamController with SteamInput API

### DIFF
--- a/library/SteamworksPy.cpp
+++ b/library/SteamworksPy.cpp
@@ -601,39 +601,32 @@ SW_PY void ActivateGameOverlayInviteDialog(int steamID) {
 //
 // Reconfigure the controller to use the specified action set.
 SW_PY void ActivateActionSet(uint64_t controllerHandle, uint64_t actionSetHandle){
-    if(SteamController() == NULL){
+    if(SteamInput() == NULL){
         return;
     }
-    SteamController()->ActivateActionSet((ControllerHandle_t) controllerHandle, (ControllerActionSetHandle_t)actionSetHandle);
+    SteamInput()->ActivateActionSet((InputHandle_t) controllerHandle, (InputActionSetHandle_t)actionSetHandle);
 }
 // Lookup the handle for an Action Set.
-SW_PY uint64_t GetActionSetHandle(const char *actionSetName) {
-    if (SteamController() == NULL) {
+SW_PY uint64_t GetActionSetHandle(char *actionSetName) {
+    if (SteamInput() == NULL) {
         return 0;
     }
-    return (uint64_t) SteamController()->GetActionSetHandle(actionSetName);
+    return (uint64_t) SteamInput()->GetActionSetHandle(actionSetName);
 }
-
 // Returns the current state of the supplied analog game action.
-//SW_PY Dictionary GetAnalogActionData(uint64_t controllerHandle, uint64_t analogActionHandle){
-//	ControllerAnalogActionData_t data;
-//	Dictionary d;
-//	memset(&data, 0, sizeof(data));
-//	if(SteamController() == NULL){
-//		data = SteamController()->GetAnalogActionData((ControllerHandle_t)controllerHandle, (ControllerAnalogActionHandle_t)analogActionHandle);
-//	}
-//	d["eMode"] = data.eMode;
-//	d["x"] = data.x;
-//	d["y"] = data.y;
-//	d["bActive"] = data.bActive;
-//	return d;
-//}
+SW_PY InputAnalogActionData_t GetAnalogActionData(uint64_t controllerHandle, uint64_t analogActionHandle){
+    InputAnalogActionData_t data;
+    if(SteamInput() != NULL){
+        data = SteamInput()->GetAnalogActionData((InputHandle_t)controllerHandle, (InputAnalogActionHandle_t)analogActionHandle);
+    }
+    return data;
+}
 // Get the handle of the specified Analog action.
 SW_PY uint64_t GetAnalogActionHandle(const char *actionName) {
-    if (SteamController() == NULL) {
+    if (SteamInput() == NULL) {
         return 0;
     }
-    return (uint64_t) SteamController()->GetAnalogActionHandle(actionName);
+    return (uint64_t) SteamInput()->GetAnalogActionHandle(actionName);
 }
 
 // Get the origin(s) for an analog action within an action.
@@ -649,57 +642,50 @@ SW_PY uint64_t GetAnalogActionHandle(const char *actionName) {
 //	return list;
 //}
 // Get current controllers handles.
-//SW_PY Array GetConnectedControllers(){
-//	Array list;
-//	if(SteamController() == NULL){
-//		ControllerHandle_t handles[STEAM_CONTROLLER_MAX_COUNT];
-//		int ret = SteamController()->GetConnectedControllers(handles);
-//		for (int i = 0; i < ret; i++){
-//			list.push_back((uint64_t)handles[i]);
-//		}
-//	}
-//	return list;
-//}
+InputHandle_t connectedControllers[STEAM_INPUT_MAX_COUNT];
+SW_PY void* GetConnectedControllers(){
+	for(int i=0; i<STEAM_INPUT_MAX_COUNT; i++){
+        connectedControllers[i] = 0;
+    }
+    if(SteamInput() != NULL) SteamInput()->GetConnectedControllers(connectedControllers);
+    return connectedControllers;
+}
 // Returns the associated controller handle for the specified emulated gamepad.
 SW_PY uint64_t GetControllerForGamepadIndex(int index) {
-    if (SteamController() == NULL) {
+    if (SteamInput() == NULL) {
         return 0;
     }
-    return (uint64_t) SteamController()->GetControllerForGamepadIndex(index);
+    return (uint64_t) SteamInput()->GetControllerForGamepadIndex(index);
 }
 
 // Get the currently active action set for the specified controller.
 SW_PY uint64_t GetCurrentActionSet(uint64_t controllerHandle){
-    if(SteamController() == NULL){
+    if(SteamInput() == NULL){
         return 0;
     }
-    return (uint64_t) SteamController()->GetCurrentActionSet((ControllerHandle_t) controllerHandle);
+    return (uint64_t) SteamInput()->GetCurrentActionSet((InputHandle_t) controllerHandle);
 }
 // Get the input type (device model) for the specified controller. 
 SW_PY uint64_t GetInputTypeForHandle(uint64_t controllerHandle){
-    if(SteamController() == NULL){
+    if(SteamInput() == NULL){
         return 0;
     }
-    return (uint64_t) SteamController()->GetInputTypeForHandle((ControllerHandle_t)controllerHandle);
+    return (uint64_t) SteamInput()->GetInputTypeForHandle((ControllerHandle_t)controllerHandle);
 }
 // Returns the current state of the supplied digital game action.
-//SW_PY Dictionary GetDigitalActionData(uint64_t controllerHandle, uint64_t digitalActionHandle){
-//	ControllerDigitalActionData_t data;
-//	Dictionary d;
-//	memset(&data, 0, sizeof(data));
-//	if(SteamController() == NULL){
-//		data = SteamController()->GetDigitalActionData((ControllerHandle_t)controllerHandle, (ControllerDigitalActionHandle_t)digitalActionHandle);
-//	}
-//	d["bState"] = data.bState;
-//	d["bActive"] = data.bActive;
-//	return d;
-//}
+SW_PY InputDigitalActionData_t GetDigitalActionData(uint64_t controllerHandle, uint64_t digitalActionHandle){
+	InputDigitalActionData_t data;
+	if(SteamInput() != NULL){
+		data = SteamInput()->GetDigitalActionData((ControllerHandle_t)controllerHandle, (ControllerDigitalActionHandle_t)digitalActionHandle);
+	}
+	return data;
+}
 // Get the handle of the specified digital action.
 SW_PY uint64_t GetDigitalActionHandle(const char *actionName) {
-    if (SteamController() == NULL) {
+    if (SteamInput() == NULL) {
         return 0;
     }
-    return (uint64_t) SteamController()->GetDigitalActionHandle(actionName);
+    return (uint64_t) SteamInput()->GetDigitalActionHandle(actionName);
 }
 
 // Get the origin(s) for an analog action within an action.
@@ -716,10 +702,10 @@ SW_PY uint64_t GetDigitalActionHandle(const char *actionName) {
 //}
 // Returns the associated gamepad index for the specified controller.
 SW_PY int GetGamepadIndexForController(uint64_t controllerHandle){
-    if(SteamController() == NULL){
+    if(SteamInput() == NULL){
         return -1;
     }
-    return SteamController()->GetGamepadIndexForController((ControllerHandle_t) controllerHandle);
+    return SteamInput()->GetGamepadIndexForController((ControllerHandle_t) controllerHandle);
 }
 
 // Returns raw motion data for the specified controller.
@@ -743,42 +729,42 @@ SW_PY int GetGamepadIndexForController(uint64_t controllerHandle){
 //	return d;
 //}
 // Start SteamControllers interface.
-SW_PY bool ControllerInit() {
-    if (SteamController() == NULL) {
+SW_PY bool ControllerInit(bool bExplicitlyCallRunFrame) {
+    if (SteamInput() == NULL) {
         return false;
     }
-    return SteamController()->Init();
+    return SteamInput()->Init(bExplicitlyCallRunFrame);
 }
 
 // Syncronize controllers.
 SW_PY void RunFrame() {
-    if (SteamController() == NULL) {
+    if (SteamInput() == NULL) {
         return;
     }
-    SteamController()->RunFrame();
+    SteamInput()->RunFrame();
 }
 
 // Invokes the Steam overlay and brings up the binding screen.
 SW_PY bool ShowBindingPanel(uint64_t controllerHandle){
-    if(SteamController()== NULL){
+    if(SteamInput()== NULL){
         return false;
     }
-    return SteamController()->ShowBindingPanel((ControllerHandle_t) controllerHandle);
+    return SteamInput()->ShowBindingPanel((ControllerHandle_t) controllerHandle);
 }
 
 // Stop SteamControllers interface.
 SW_PY bool ControllerShutdown() {
-    if (SteamController() == NULL) {
+    if (SteamInput() == NULL) {
         return false;
     }
-    return SteamController()->Shutdown();
+    return SteamInput()->Shutdown();
 }
 // Trigger a vibration event on supported controllers.
 SW_PY void TriggerVibration(uint64_t controllerHandle, uint16_t leftSpeed, uint16_t rightSpeed){
-    if(SteamController()== NULL){
+    if(SteamInput()== NULL){
         return;
     }
-    SteamController()->TriggerVibration((ControllerHandle_t) controllerHandle, (unsigned short)leftSpeed, (unsigned short)rightSpeed);
+    SteamInput()->TriggerVibration((ControllerHandle_t) controllerHandle, (unsigned short)leftSpeed, (unsigned short)rightSpeed);
 }
 
 /////////////////////////////////////////////////

--- a/steamworks/__init__.py
+++ b/steamworks/__init__.py
@@ -30,6 +30,7 @@ from steamworks.interfaces.userstats    import SteamUserStats
 from steamworks.interfaces.utils        import SteamUtils
 from steamworks.interfaces.workshop     import SteamWorkshop
 from steamworks.interfaces.microtxn     import SteamMicroTxn
+from steamworks.interfaces.input        import SteamInput
 
 os.environ['LD_LIBRARY_PATH'] = os.getcwd()
 
@@ -133,6 +134,7 @@ class STEAMWORKS(object):
         self.Utils          = SteamUtils(self)
         self.Workshop       = SteamWorkshop(self)
         self.MicroTxn       = SteamMicroTxn(self)
+        self.Input          = SteamInput(self)
 
 
     def initialize(self) -> bool:

--- a/steamworks/__init__.py
+++ b/steamworks/__init__.py
@@ -67,7 +67,12 @@ class STEAMWORKS(object):
         library_file_name = ''
         if platform in ['linux', 'linux2']:
             library_file_name = 'SteamworksPy.so'
-            cdll.LoadLibrary(os.path.join(os.getcwd(), 'libsteam_api.so')) #if i do this then linux works
+            if os.path.isfile(os.path.join(os.getcwd(), 'libsteam_api.so')):
+                cdll.LoadLibrary(os.path.join(os.getcwd(), 'libsteam_api.so')) #if i do this then linux works
+            elif os.path.isfile(os.path.join(os.path.dirname(__file__), 'libsteam_api.so')):
+                cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'libsteam_api.so'))
+            else:
+                raise MissingSteamworksLibraryException(f'Missing library "libsteam_api.so"')
 
         elif platform == 'darwin':
             library_file_name = 'SteamworksPy.dylib'
@@ -79,9 +84,12 @@ class STEAMWORKS(object):
             # This case is theoretically unreachable
             raise UnsupportedPlatformException(f'"{platform}" is not being supported')
 
-        library_path = os.path.join(os.getcwd(), library_file_name)
-        if not os.path.isfile(library_path):
-            raise MissingSteamworksLibraryException(f'Missing library at {library_path}')
+        if os.path.isfile(os.path.join(os.getcwd(), library_file_name)):
+            library_path = os.path.join(os.getcwd(), library_file_name)
+        elif os.path.isfile(os.path.join(os.path.dirname(__file__), library_file_name)):
+            library_path = os.path.join(os.path.dirname(__file__), library_file_name)
+        else:
+            raise MissingSteamworksLibraryException(f'Missing library {library_file_name}')
 
         app_id_file = os.path.join(os.getcwd(), 'steam_appid.txt')
         if not os.path.isfile(app_id_file):

--- a/steamworks/interfaces/input.py
+++ b/steamworks/interfaces/input.py
@@ -1,0 +1,41 @@
+from steamworks.enums 		import *
+from steamworks.structs 	import *
+from steamworks.exceptions 	import *
+
+
+class SteamInput:
+    def __init__(self, steam: object):
+        self.steam = steam
+        if not self.steam.loaded():
+            raise SteamNotLoadedException('STEAMWORKS not yet loaded')
+
+    def Init(self, explicitlyCallRunFrame=False):
+        return self.steam.ControllerInit(explicitlyCallRunFrame)
+
+    def RunFrame(self):
+        return self.steam.RunFrame()
+
+    def GetConnectedControllers(self) -> list[int]:
+        controllers_array = self.steam.GetConnectedControllers()
+        return [controller for i in range(16) if (controller := controllers_array[i]) != 0]
+
+    def GetControllerForGamepadIndex(self, index: int) -> int:
+        return self.steam.GetControllerForGamepadIndex(index)
+
+    def GetActionSetHandle(self, name: str) -> int:
+        return self.steam.GetActionSetHandle(name.encode('ascii'))
+
+    def ActivateActionSet(self, controller, action_set):
+        return self.steam.ActivateActionSet(controller, action_set)
+
+    def GetAnalogActionHandle(self, name: str) -> int:
+        return self.steam.GetAnalogActionHandle(name.encode('ascii'))
+
+    def GetAnalogActionData(self, controller, analog_action):
+        return self.steam.GetAnalogActionData(controller, analog_action)
+
+    def GetDigitalActionHandle(self, name: str) -> int:
+        return self.steam.GetDigitalActionHandle(name.encode('ascii'))
+
+    def GetDigitalActionData(self, controller, digital_action):
+        return self.steam.GetDigitalActionData(controller, digital_action)

--- a/steamworks/methods.py
+++ b/steamworks/methods.py
@@ -6,6 +6,17 @@ from ctypes import *
 # (ala CFUNCTYPE vs WINFUNCTYPE), but so far even on Win64, it's all cdecl
 MAKE_CALLBACK = CFUNCTYPE
 
+class InputAnalogActionData_t(Structure):
+    _fields_ = [('eMode', c_uint32),
+                ('x', c_float),
+                ('y', c_float),
+                ('bActive', c_bool)]
+
+class InputDigitalActionData_t(Structure):
+    _fields_ = [('bState', c_bool),
+                ('bActive', c_bool)]
+
+
 STEAMWORKS_METHODS = {
     'SteamShutdown': {
         'restype': None
@@ -125,13 +136,20 @@ STEAMWORKS_METHODS = {
         'argtypes': [c_uint64]
     },
     'ActivateActionSet': {
-        'restype': None
+        'restype': None,
+        'argtypes': [c_uint64, c_uint64]
     },
     'GetActionSetHandle': {
-        'restype': c_uint64
+        'restype': c_uint64,
+        'argtypes': [c_char_p]
     },
     'GetAnalogActionHandle': {
-        'restype': c_uint64
+        'restype': c_uint64,
+        'argtypes': [c_char_p]
+    },
+    'GetAnalogActionData': {
+        'restype': InputAnalogActionData_t,
+        'argtypes': [c_uint64, c_uint64]
     },
     'GetControllerForGamepadIndex': {
         'restype': c_uint64
@@ -139,17 +157,25 @@ STEAMWORKS_METHODS = {
     'GetCurrentActionSet': {
         'restype': c_uint64
     },
+    'GetConnectedControllers': {
+        'restype': POINTER(c_uint64)
+    },
     'GetInputTypeForHandle': {
         'restype': c_uint64
     },
     'GetDigitalActionHandle': {
         'restype': c_uint64
     },
+    'GetDigitalActionData': {
+        'restype': InputDigitalActionData_t,
+        'argtypes': [c_uint64, c_uint64]
+    },
     'GetGamepadIndexForController': {
         'restype': int
     },
     'ControllerInit': {
-        'restype': bool
+        'restype': bool,
+        'argtypes': [c_bool]
     },
     'RunFrame': {
         'restype': None


### PR DESCRIPTION
The SteamController interface has been deprecated: https://partner.steamgames.com/doc/api/ISteamController

As an improvement, I've also added that it searches for .dll/.so library files for `SteamworksPy` and `libsteam_api` in the directory of the steamworks python library. With this, the library files are all in one place, instead of the user project folder.