### PR TITLE
Add SteamInput's SetInputActionManifestFilePath

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -1,4 +1,5 @@
-makeall:
+SteamworksPy.so: SteamworksPy.cpp
 	g++ -std=c++11 -o SteamworksPy.so -shared -fPIC SteamworksPy.cpp -l steam_api -L.
+
 clean:
 	rm SteamworksPy.so

--- a/library/SteamworksPy.cpp
+++ b/library/SteamworksPy.cpp
@@ -13,6 +13,7 @@
 #include "TargetConditionals.h"
 #define SW_PY extern "C" __attribute__ ((visibility("default")))
 #elif defined( __linux__ )
+#include <cstdint>
 #include "sdk/steam/steam_api.h"
 #define SW_PY extern "C" __attribute__ ((visibility("default")))
 #else
@@ -665,7 +666,7 @@ SW_PY uint64_t GetCurrentActionSet(uint64_t controllerHandle){
     }
     return (uint64_t) SteamInput()->GetCurrentActionSet((InputHandle_t) controllerHandle);
 }
-// Get the input type (device model) for the specified controller. 
+// Get the input type (device model) for the specified controller.
 SW_PY uint64_t GetInputTypeForHandle(uint64_t controllerHandle){
     if(SteamInput() == NULL){
         return 0;
@@ -734,6 +735,13 @@ SW_PY bool ControllerInit(bool bExplicitlyCallRunFrame) {
         return false;
     }
     return SteamInput()->Init(bExplicitlyCallRunFrame);
+}
+
+SW_PY bool SetInputActionManifestFilePath(const char *path) {
+    if (SteamInput() == NULL) {
+        return false;
+    }
+    return SteamInput()->SetInputActionManifestFilePath(path);
 }
 
 // Syncronize controllers.
@@ -1468,3 +1476,4 @@ SW_PY void MicroTxn_SetAuthorizationResponseCallback(MicroTxnAuthorizationRespon
     }
     microtxn.SetAuthorizationResponseCallback(callback);
 }
+

--- a/steamworks/interfaces/input.py
+++ b/steamworks/interfaces/input.py
@@ -12,6 +12,9 @@ class SteamInput:
     def Init(self, explicitlyCallRunFrame=False):
         return self.steam.ControllerInit(explicitlyCallRunFrame)
 
+    def SetInputActionManifestFilePath(self, path):
+        return self.steam.SetInputActionManifestFilePath(path.encode())
+
     def RunFrame(self):
         return self.steam.RunFrame()
 

--- a/steamworks/methods.py
+++ b/steamworks/methods.py
@@ -135,6 +135,10 @@ STEAMWORKS_METHODS = {
         'restype': None,
         'argtypes': [c_uint64]
     },
+    'SetInputActionManifestFilePath': {
+        'restype': bool,
+        'argtypes': [c_char_p]
+    },
     'ActivateActionSet': {
         'restype': None,
         'argtypes': [c_uint64, c_uint64]


### PR DESCRIPTION
The method is not documented in steamworks docs. It allows one to provide SteamInput with a vdf manifest describing controller actions.

It is extremely useful when you are not a real steam developer, but still want to play with steam input on your steam deck

Usage:
```python
if not STEAMWORKS.Input.SetInputActionManifestFilePath(ABSOLUTE_PATH_TO_VDF_FILE):
    raise InitError("cannot load vdf")
```

Any ways we can build it on CI? I mean can we legally use the steamworks SDK for it?