### PR TITLE
Fix function used for Friends.ActivateGameOverlayToStore

### DIFF
--- a/steamworks/interfaces/friends.py
+++ b/steamworks/interfaces/friends.py
@@ -129,7 +129,7 @@ class SteamFriends(object):
         :param app_id: int
         :return: None
         """
-        self.steam.ActivateGameOverlayToWebPage(app_id)
+        self.steam.ActivateGameOverlayToStore(app_id)
 
 
     def ActivateGameOverlayInviteDialog(self, steam_lobby_id: int) -> None:


### PR DESCRIPTION
I was getting a crash when trying to use `Friends.ActivateGameOverlayToStore()`.

```
  File "[...]\steamworks\interfaces\friends.py", line 132, in ActivateGameOverlayToStore
    self.steam.ActivateGameOverlayToWebPage(app_id)
ctypes.ArgumentError: argument 1: TypeError: wrong type
```

It looks like the function was mapped incorrectly in `interfaces/friends.py`. Changing to the matching function fixed the issue for me.